### PR TITLE
Support RSpec 3

### DIFF
--- a/lib/rspec/request_describer.rb
+++ b/lib/rspec/request_describer.rb
@@ -46,7 +46,8 @@ module RSpec
         end
 
         let(:endpoint_segments) do
-          example.full_description.match(/(#{SUPPORTED_METHODS.join("|")}) ([\/a-z0-9_:]+)/).to_a
+          current_example = RSpec.respond_to?(:current_example) ? RSpec.current_example : example
+          current_example.full_description.match(/(#{SUPPORTED_METHODS.join("|")}) ([\/a-z0-9_:]+)/).to_a
         end
 
         let(:method) do


### PR DESCRIPTION
The API to access the current example object has been changed in RSpec 3.

https://github.com/yujinakayama/transpec#current-example-object
