### PR TITLE
Not use `in?` method (extend activesupport)

### DIFF
--- a/lib/rspec/request_describer.rb
+++ b/lib/rspec/request_describer.rb
@@ -39,7 +39,7 @@ module RSpec
 
         let(:env) do
           headers.inject({}) do |result, (key, value)|
-            key = "HTTP_" + key unless key.in?(RESERVED_HEADER_NAMES)
+            key = "HTTP_" + key unless RESERVED_HEADER_NAMES.include?(key)
             key = key.gsub("-", "_").upcase
             result.merge(key => value)
           end


### PR DESCRIPTION
## Background

I use this gem (v0.0.2) and got error message following:

```
# spec
# describe 'POST /' do
#   before do
#     headers['X_GITHUB_EVENT'] = 'issue_comment'
#   end
#   it { ... }
# end

NoMethodError:
  undefined method `in?' for "X_GITHUB_EVENT":String
```
## Cause

I think `in?` method that have been use [here](https://github.com/r7kamura/rspec-request_describer/blob/v0.0.2/lib/rspec/request_describer.rb#L42) is [extend activesupport method](https://github.com/rails/rails/blob/v4.1.6/activesupport/lib/active_support/core_ext/object/inclusion.rb#L10-L14) (maybe...).
But this gem has not been written in `.gemspec` **activesupport is required**.
## So

I have rewritten as commit.
If you want to use `in?` method, I add activesupport in gemspec.
