### PR TITLE
Prefix private APIs with underscore to avoid name collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.0.10
+- Private APIs `#request_body`, `#env`, `#endpoint_segments`, `#method` and `#path`
+  are now prefixed with `_` to avoid name collision and override of `Object#method`.
+
 ## 0.0.9
 - Ignore case-sensivity on Content-Type checking
 

--- a/lib/rspec/request_describer.rb
+++ b/lib/rspec/request_describer.rb
@@ -18,11 +18,7 @@ module RSpec
 
     def self.included(base)
       base.instance_eval do
-        subject do
-          send_request
-        end
-
-        let(:send_request) do
+        subject(:send_request) do
           send _method, _path, _request_body, _env
         end
 

--- a/lib/rspec/request_describer.rb
+++ b/lib/rspec/request_describer.rb
@@ -23,15 +23,7 @@ module RSpec
         end
 
         let(:send_request) do
-          send method, path, request_body, env
-        end
-
-        let(:request_body) do
-          if headers.any? { |key, value| key.downcase == "content-type" && value == "application/json" }
-            params.to_json
-          else
-            params
-          end
+          send _method, _path, _request_body, _env
         end
 
         let(:headers) do
@@ -42,7 +34,17 @@ module RSpec
           {}
         end
 
-        let(:env) do
+        # @private
+        let(:_request_body) do
+          if headers.any? { |key, value| key.downcase == "content-type" && value == "application/json" }
+            params.to_json
+          else
+            params
+          end
+        end
+
+        # @private
+        let(:_env) do
           headers.inject({}) do |result, (key, value)|
             key = "HTTP_" + key unless RESERVED_HEADER_NAMES.include?(key)
             key = key.gsub("-", "_").upcase
@@ -50,17 +52,20 @@ module RSpec
           end
         end
 
-        let(:endpoint_segments) do
+        # @private
+        let(:_endpoint_segments) do
           current_example = RSpec.respond_to?(:current_example) ? RSpec.current_example : example
           current_example.full_description.match(/(#{SUPPORTED_METHODS.join("|")}) (\S+)/).to_a
         end
 
-        let(:method) do
-          endpoint_segments[1].downcase
+        # @private
+        let(:_method) do
+          _endpoint_segments[1].downcase
         end
 
-        let(:path) do
-          endpoint_segments[2].gsub(/:(\w+[!?=]?)/) { send($1) }
+        # @private
+        let(:_path) do
+          _endpoint_segments[2].gsub(/:(\w+[!?=]?)/) { send($1) }
         end
       end
     end


### PR DESCRIPTION
Some of the private APIs like `#env`, `#method` and `#path` are too generic name and they tend to collide with user-defined helper methods, and also `#method` is accidentally overriding `Object#method`.

I considered APIs described in the README – `#subject` (`#send_request`),  `#headers`, `#params` – are public, and the rest of them are private. So I don't think this is a breaking change. Let me know if there're any concerns.