### PR TITLE
Prevent warning for Rails 5

### DIFF
--- a/lib/rspec/request_describer.rb
+++ b/lib/rspec/request_describer.rb
@@ -22,8 +22,14 @@ module RSpec
           send_request
         end
 
-        let(:send_request) do
-          send http_method, path, request_body, env
+        if (ActionDispatch::Integration::Session.instance_method(:process_with_kwargs) rescue false)
+          let(:send_request) do
+            send http_method, path, params: request_body, headers: env
+          end
+        else
+          let(:send_request) do
+            send http_method, path, request_body, env
+          end
         end
 
         let(:request_body) do


### PR DESCRIPTION
In Rails 5, send_request occurs the following warning message.
It is because the use of keyword arguments are recommended in Rails 5.

```
DEPRECATION WARNING: ActionDispatch::IntegrationTest HTTP request methods will accept only                                                                                                                                                                                                                                                                 |  ETA: ??:??:??
the following keyword arguments in future Rails versions:
params, headers, env, xhr

Examples:

get '/profile',
  params: { id: 1 },
  headers: { 'X-Extra-Header' => '123' },
  env: { 'action_dispatch.custom' => 'custom' },
  xhr: true
 (called from block (3 levels) in <top (required)> at /Users/mrkn/work/xxxx/spec/requests/xxxx/xxxx_spec.rb:13)

```