### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Then include `RSpec::RequestDescriber` into your `RSpec.configuration`.
 
 ```ruby
 # spec/spec_helper.rb
-RSpec.configuration.include RSpec::RequestDescriber
+RSpec.configuration.include RSpec::RequestDescriber, type: :request
 ```
 
 ## Usage


### PR DESCRIPTION
I've got NoMethodError when including RSpec::RequestDescriber without specify the type metadata.

```
     NoMethodError:
       undefined method `downcase' for nil:NilClass
     # /bundle/gems/rspec-request_describer-0.1.1/lib/rspec/request_describer.rb:65:in `block (2 levels) in included'
     # /bundle/gems/rspec-request_describer-0.1.1/lib/rspec/request_describer.rb:27:in `block (2 levels) in included'
     # /bundle/gems/rspec-request_describer-0.1.1/lib/rspec/request_describer.rb:22:in `block (2 levels) in included'
```
