### PR TITLE
Recommend including mix-in module only into request specs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Then include `RSpec::RequestDescriber` into your `RSpec.configuration`.
 
 ```ruby
 # spec/spec_helper.rb
-RSpec.configuration.include RSpec::RequestDescriber
+RSpec.configuration.include RSpec::RequestDescriber, type: :request
 ```
 
 ## Usage


### PR DESCRIPTION
... so that it does not pollute other specs.
