### PR TITLE
exclude to_json when GET request

### DIFF
--- a/lib/rspec/request_describer.rb
+++ b/lib/rspec/request_describer.rb
@@ -33,7 +33,7 @@ module RSpec
         end
 
         let(:request_body) do
-          if headers.any? { |key, value| key.downcase == "content-type" && value == "application/json" }
+          if headers.any? { |key, value| key.downcase == "content-type" && value == "application/json" } && http_method != 'get'
             params.to_json
           else
             params


### PR DESCRIPTION
Hi!

GET request params encode to JSON now with content-type == application/json.
I want to exclude to_json when all GET requests.

What do you think?
