### PR TITLE
HTTP header fields are case-insensitive

### DIFF
--- a/lib/rspec/request_describer.rb
+++ b/lib/rspec/request_describer.rb
@@ -3,9 +3,9 @@ require "rspec/request_describer/version"
 module RSpec
   module RequestDescriber
     RESERVED_HEADER_NAMES = %w(
-      Content-Type
-      Host
-      HTTPS
+      content-type
+      host
+      https
     )
 
     SUPPORTED_METHODS = %w(
@@ -50,7 +50,7 @@ module RSpec
 
           let(:env) do
             headers.inject({}) do |result, (key, value)|
-              key = "HTTP_" + key unless RESERVED_HEADER_NAMES.include?(key)
+              key = "HTTP_" + key unless RESERVED_HEADER_NAMES.include?(key.downcase)
               key = key.gsub("-", "_").upcase
               result.merge(key => value)
             end


### PR DESCRIPTION
With current version of this gem, `headers['CONTENT-TYPE'] = 'application/json'` or `headers['content-type'] = 'application/json'` makes params encoded as JSON, but HTTP header field 'content-type' will remain as 'application/x-www-form-urlencoded'.
This pull request solved this problem.

(According to RFC7230, HTTP header fields are case-insensitive.
https://tools.ietf.org/html/rfc7230#section-3.2)