### PR TITLE
Allow headers to depend on the request body

### DIFF
--- a/lib/rspec/request_describer.rb
+++ b/lib/rspec/request_describer.rb
@@ -33,7 +33,7 @@ module RSpec
           end
 
           let(:request_body) do
-            if env['CONTENT_TYPE'] == 'application/json'
+            if headers.any? { |key, value| key.to_s.casecmp('content-type').zero? && value == 'application/json' }
               params.to_json
             else
               params.inject({}) do |result, (key, value)|

--- a/spec/rspec/request_describer_spec.rb
+++ b/spec/rspec/request_describer_spec.rb
@@ -1,3 +1,5 @@
+require 'openssl'
+
 RSpec.describe RSpec::RequestDescriber do
   include RSpec::RequestDescriber
 
@@ -62,6 +64,23 @@ RSpec.describe RSpec::RequestDescriber do
             :get,
             '/users',
             headers: { 'HTTP_AUTHORIZATION' => 'token 12345' },
+            params: {}
+          ]
+        )
+      end
+    end
+
+    context 'with headers including request body' do
+      before do
+        headers['X-Signature'] = "sha1=#{OpenSSL::HMAC.hexdigest('SHA1', 'secret', request_body.to_s)}"
+      end
+
+      it 'calls #get with HTTP_ prefixed and stringified keys headers' do
+        is_expected.to eq(
+          [
+            :get,
+            '/users',
+            headers: { 'HTTP_X_SIGNATURE' => 'sha1=5d61605c3feea9799210ddcb71307d4ba264225f' },
             params: {}
           ]
         )


### PR DESCRIPTION
First of all, thanks for the great gem!

In v0.3, `env` is evaluated when `request_body` is evaluated, so the request headers are fixed at this time. But we want to calculate a header value depending on the value of the request body in some cases (Imagine something like a webhook signature).

For these reasons, this pull request will remove the reference to `env` from the request body.