### PR TITLE
Relax dependency

### DIFF
--- a/rspec-request_describer.gemspec
+++ b/rspec-request_describer.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'actionpack', '>= 5.0.0'
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
Rails's request test has been changed to kwargs since v5.0, but
rspec-request_describer can still be used with rack-test (by overriding `send_request`).

This gem does not depends on actionpack when used with rack-test.