### PR TITLE
Clarify error message when a test case is in incorrect `describe`

### DIFF
--- a/lib/rspec/request_describer.rb
+++ b/lib/rspec/request_describer.rb
@@ -2,6 +2,8 @@ require 'rspec/request_describer/version'
 
 module RSpec
   module RequestDescriber
+    class IncorrectDescribe < StandardError; end
+
     RESERVED_HEADER_NAMES = %w[
       content-type
       host
@@ -62,7 +64,10 @@ module RSpec
 
           let(:endpoint_segments) do
             current_example = ::RSpec.respond_to?(:current_example) ? ::RSpec.current_example : example
-            current_example.full_description.match(/(#{::Regexp.union(SUPPORTED_METHODS)}) (\S+)/).to_a
+            match = current_example.full_description.match(/(#{::Regexp.union(SUPPORTED_METHODS)}) (\S+)/)
+            raise IncorrectDescribe, 'Please use the format "METHOD /path" for the describe' unless match
+
+            match.to_a
           end
 
           # @return [String] e.g. `"get"`

--- a/spec/rspec/request_describer_spec.rb
+++ b/spec/rspec/request_describer_spec.rb
@@ -138,4 +138,10 @@ RSpec.describe RSpec::RequestDescriber do
       )
     end
   end
+
+  context 'when the test case is under the top-level describe unexpectedly' do
+    it 'handles the error' do
+      expect { subject }.to raise_error(RSpec::RequestDescriber::IncorrectDescribe)
+    end
+  end
 end


### PR DESCRIPTION
This PR improves the error message when a test case is in incorrect `describe`.



## Problem

This gem raises an error with the following test code because it does not have a correct `describe` with `METHOD /path` format.

```ruby
RSpec.describe MyClass do
  context 'when ...' do
    it do
      subject
    end
  end
end
```

It should raise an error, but the error message is not helpful like the following:

```
     Failure/Error: endpoint_segments[1].downcase
     
     NoMethodError:
       undefined method `downcase' for nil
```

The error caused from here: https://github.com/r7kamura/rspec-request_describer/blob/69e4b16fff462e515fe13000a0662512c4f90e73/lib/rspec/request_describer.rb#L70


It is hard to realize the `describe` is wrong. 





## Solution


Handle the error explicitly. By this change, the user will see the following message:


```
     Failure/Error: raise IncorrectDescribe, 'Please use the format "METHOD /path" for the describe' unless match
       Please use the format "METHOD /path" for the describe
```

It is more understandable how to fix the problem. 

-------


BTW, I actually got the error while I added a test case to like the following spec.

```ruby
RSpec.describe MyClass do
  describe 'GET /home' do
    # many lines to test /home
    # ...


    # I wanted to add a test case into here
  end

  # but actually I mistakenly added it here.
end
```

