### PR TITLE
Update Bundler version from 2.2.29 to 2.6.9 in Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,4 +58,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   2.2.29
+   2.6.9


### PR DESCRIPTION
Fix old bundler version causing `bundle install` to fail.
```
❯ bundle install
Bundler 2.6.7 is running, but your lockfile was generated with 2.2.29. Installing Bundler 2.2.29 and restarting using that version.
Fetching gem metadata from https://rubygems.org/.
Fetching bundler 2.2.29
Installing bundler 2.2.29
/ydah/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.2.29/lib/bundler/vendor/thor/lib/thor/error.rb:105:in '<class:Thor>': uninitialized constant DidYouMean::SPELL_CHECKERS (NameError)

    DidYouMean::SPELL_CHECKERS.merge!(
              ^^^^^^^^^^^^^^^^
Did you mean?  DidYouMean::SpellChecker
        from /ydah/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.2.29/lib/bundler/vendor/thor/lib/thor/error.rb:1:in '<top (required)>'
        from /ydah/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.2.29/lib/bundler/vendor/thor/lib/thor/base.rb:3:in 'Kernel#require_relative'
        from /ydah/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.2.29/lib/bundler/vendor/thor/lib/thor/base.rb:3:in '<top (required)>'
        from /ydah/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.2.29/lib/bundler/vendor/thor/lib/thor.rb:1:in 'Kernel#require_relative'
        from /ydah/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.2.29/lib/bundler/vendor/thor/lib/thor.rb:1:in '<top (required)>'
        from /ydah/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.2.29/lib/bundler/vendored_thor.rb:8:in 'Kernel#require_relative'
        from /ydah/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.2.29/lib/bundler/vendored_thor.rb:8:in '<top (required)>'
        from /ydah/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.2.29/lib/bundler/friendly_errors.rb:3:in 'Kernel#require_relative'
        from /ydah/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.2.29/lib/bundler/friendly_errors.rb:3:in '<top (required)>'
        from /ydah/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.2.29/exe/bundle:32:in 'Kernel#require_relative'
        from /ydah/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/bundler-2.2.29/exe/bundle:32:in '<top (required)>'
        from /ydah/.rbenv/versions/3.4.4/bin/bundle:25:in 'Kernel#load'
        from /ydah/.rbenv/versions/3.4.4/bin/bundle:25:in '<main>'
```