### PR TITLE
Support query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ RSpec.describe 'GET /users' do
   let(:params) do
     {}
   end
+  
+  let(:query) do
+    {}
+  end
 
   it 'returns 200' do
     subject
@@ -136,6 +140,25 @@ RSpec.describe 'GET /users/:user_id' do
   it 'returns 200' do
     subject
     expect(response).to have_http_status(200)
+  end
+end
+```
+
+### query parameters
+
+If you want to modify query parameters, change `query`:
+
+```ruby
+RSpec.describe 'GET /users' do
+  context 'with query parameter' do
+    let(:query)
+      { status: 'active', sort: 'id' }
+    end
+
+    it 'returns 200' do
+      subject
+      expect(path).to eq 'users?status=active&sort=id'
+    end
   end
 end
 ```

--- a/lib/rspec/request_describer.rb
+++ b/lib/rspec/request_describer.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'rspec/request_describer/version'
+require 'uri'
 
 module RSpec
   module RequestDescriber
@@ -78,7 +79,13 @@ module RSpec
           end
 
           let(:path) do
-            endpoint_segments[2].gsub(/:(\w+[!?=]?)/) { send(Regexp.last_match(1)) }
+            query_string = ::URI.encode_www_form(query)
+            path = endpoint_segments[2].gsub(/:(\w+[!?=]?)/) { send(Regexp.last_match(1)) }
+            "#{path}#{query_string.empty? ? '' : "?#{query_string}"}"
+          end
+
+          let(:query) do
+            {}
           end
         end
       end

--- a/spec/rspec/request_describer_spec.rb
+++ b/spec/rspec/request_describer_spec.rb
@@ -122,6 +122,23 @@ RSpec.describe RSpec::RequestDescriber do
         )
       end
     end
+
+    context 'with query' do
+      let(:query) do
+        super().merge(status: 'active', sort: 'id')
+      end
+
+      it 'calls #get with query string' do
+        is_expected.to eq(
+          [
+            :get,
+            '/users?status=active&sort=id',
+            { headers: {},
+              params: {} }
+          ]
+        )
+      end
+    end
   end
 
   describe 'GET /users/:user_id' do


### PR DESCRIPTION
## Motivation / Background

In request spec, even if you set query parameters to 
`params`, we can set values to Controller's `params`.

```ruby
describe ‘GET /users’ do
  let(:params) { status: ‘active’ }

  it ‘returns 200’ do
    # below is equal to `get ‘/users’, params:`
    subject # On UsersController, params[:status] returns ‘active’
    expect(response).to have_http_status 200
  end
end
```

However, when `application/json` is set for `Content-Type`, RSpec::RequestDescriber converts `params` to a JSON string using `to_json`, so even if query parameters are set in `params`, the test will not work correctly.

```ruby
describe ‘GET /users’ do
  before do
    headers[‘content-type’] = ‘application/json’
  end

  let(:params) do
    { status: ‘active’ }
  end

  it ‘returns 200’ do
    subject # On UsersController, params[:status] returns nil
    expect(response).to have_http_status 200
  end
end
```

In actual behavior, query parameters should be included in the `path`, and it is preferable to verify the actual behavior as much as possible in tests.

## Details

I added `query`. It can be defined as Hash, similar to `params`. Defining as String is not supported.